### PR TITLE
Mass point seeding via rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem 'globalize-accessors'
 gem 'rails-html-sanitizer'
 gem 'geocoder', '~> 1.3.4'
 gem 'simple_captcha2', require: 'simple_captcha'
-gem 'pry'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,7 +331,6 @@ DEPENDENCIES
   minitest-reporters
   pg
   poltergeist
-  pry
   rails (= 4.2.5.1)
   rails-html-sanitizer
   rubocop

--- a/lib/mass_seed_points.rb
+++ b/lib/mass_seed_points.rb
@@ -1,0 +1,88 @@
+require 'geocoder'
+
+module MassSeedPoints
+  # Helpers
+  def self.random_latin_string(characters = 10)
+    (0...characters).map { ('a'..'z').to_a[rand(26)] }.join
+  end
+
+  def self.random_arab_string(characters = 10)
+    (0...characters).map { ('ا'..'غ').to_a[rand(28)] }.join
+  end
+
+  def self.latin_lorem_ipsum(words = 100)
+    lorem_ipsum = (0..words).map { random_latin_string(rand(2..26)) }.join(' ')
+    "<b>#{random_latin_string(rand(5..10))}</b> <br><br>" + lorem_ipsum
+  end
+
+  def self.arab_lorem_ipsum(words = 100)
+    lorem_ipsum = (0..words).map { random_arab_string(rand(2..26)) }.join(' ')
+    "<b>#{random_arab_string(rand(5..10))}</b> <br><br>" + lorem_ipsum
+  end
+
+  def self.bbox_from_cityname(cityname)
+    Geocoder.search(cityname).first.boundingbox
+  end
+
+  def self.random_point_inside_bbox(bbox)
+    latitudes = [bbox[0], bbox[1]]
+    longitudes = [bbox[2], bbox[3]]
+    { latitude: rand(latitudes.min..latitudes.max),
+      longitude: rand(longitudes.min..longitudes.max) }
+  end
+
+  def self.n_random_digits(n = 5, from = 0, to = 9)
+    n.times.map { rand(from..to) }.join('')
+  end
+
+  # Generator methods for points and categories
+  def self.generate_point(no_of_categories=3, bbox)
+    random_point = random_point_inside_bbox(bbox)
+    category_ids = Category.all.map(&:id)
+    place_id = Place.last.id + 1
+
+    Place.new(id: place_id,
+              name: random_latin_string(rand(10..20)),
+              street: random_latin_string(rand(5..10)).capitalize + '-Straße',
+              house_number: n_random_digits(rand(1..3), 1),
+              postal_code: n_random_digits,
+              city: @cityname,
+              latitude: random_point[:latitude],
+              longitude: random_point[:longitude],
+              description_en: latin_lorem_ipsum(rand(10..90)),
+              description_de: latin_lorem_ipsum(rand(10..90)),
+              description_fr: latin_lorem_ipsum(rand(10..90)),
+              description_ar: arab_lorem_ipsum(rand(10..90)),
+             ).save(validate: false)
+
+    no_of_categories.times do
+      Categorizing.create(category_id: category_ids.shuffle.pop,
+                          place_id: place_id)
+    end
+  end
+
+  def self.generate_category
+    id_nr = Category.any && (Category.all.map(&:id).max + 1) || 1
+    Category.create(id: id_nr,
+                    name_en: random_latin_string,
+                    name_de: random_latin_string,
+                    name_fr: random_latin_string,
+                    name_ar: random_arab_string
+                   )
+  end
+
+  def self.generate(number_of_points:, city:)
+    @cityname = city
+    bbox = bbox_from_cityname(@cityname).map(&:to_f)
+
+    # Create up to 10 categories
+    amount_of_new_categories = 10 - Category.all.count
+    amount_of_new_categories.times { generate_category }
+
+    # Create n points
+    number_of_points.times.with_index do |i|
+      generate_point(rand(1..5), bbox)
+      STDOUT.write "\rGenerating points: point #{i + 1}/#{number_of_points} created"
+    end
+  end
+end

--- a/lib/mass_seed_points.rb
+++ b/lib/mass_seed_points.rb
@@ -21,7 +21,8 @@ module MassSeedPoints
   end
 
   def self.bbox_from_cityname(cityname)
-    Geocoder.search(cityname).first.boundingbox
+      result = Geocoder.search(cityname).first
+      result && results.boundingbox.map(&:to_f) || nil
   end
 
   def self.random_point_inside_bbox(bbox)
@@ -62,7 +63,7 @@ module MassSeedPoints
   end
 
   def self.generate_category
-    id_nr = Category.any && (Category.all.map(&:id).max + 1) || 1
+    id_nr = Category.any? && (Category.all.map(&:id).max + 1) || 1
     Category.create(id: id_nr,
                     name_en: random_latin_string,
                     name_de: random_latin_string,
@@ -73,7 +74,11 @@ module MassSeedPoints
 
   def self.generate(number_of_points:, city:)
     @cityname = city
-    bbox = bbox_from_cityname(@cityname).map(&:to_f)
+    unless bbox = bbox_from_cityname(@cityname)
+      error = "No boundingbox found in which to insert points! Have you supplied a geolocation (city, district, ...)?"
+      puts error
+      return error
+    end
 
     # Create up to 10 categories
     amount_of_new_categories = 10 - Category.all.count

--- a/lib/tasks/mass_seed_points.rake
+++ b/lib/tasks/mass_seed_points.rake
@@ -1,0 +1,7 @@
+require 'mass_seed_points'
+
+desc 'mass_seed_points'
+task mass_seed_points: :environment do
+  ARGV.each { |a| task a.to_sym do ; end }
+  MassSeedPoints.generate(number_of_points: ARGV[1].to_i, city: ARGV[2])
+end

--- a/lib/tasks/mass_seed_points.rake
+++ b/lib/tasks/mass_seed_points.rake
@@ -3,5 +3,5 @@ require 'mass_seed_points'
 desc 'mass_seed_points'
 task mass_seed_points: :environment do
   ARGV.each { |a| task a.to_sym do ; end }
-  MassSeedPoints.generate(number_of_points: ARGV[1].to_i, city: ARGV[2])
+  MassSeedPoints.generate(number_of_points: ARGV[1].to_i, region_name: ARGV[2])
 end

--- a/test/lib/mass_seed_points_test.rb
+++ b/test/lib/mass_seed_points_test.rb
@@ -1,0 +1,24 @@
+require_relative '../test_helper'
+require 'mass_seed_points'
+
+class MassSeedPointsTest < ActiveSupport::TestCase
+  def setup
+  end
+
+  test 'can generate 1 point in Berlin Lichtenberg' do
+    assert 'Place.count', 1 do
+      MassSeedPoints.generate(number_of_points: 1, city: 'Berlin, Lichtenberg')
+    end
+  end
+
+  test '0 Points returns error message' do
+    assert 'Place.count', 0 do
+      MassSeedPoints.generate(number_of_points: 0, city: 'Berlin, Lichtenberg')
+    end
+  end
+
+  test 'No Region returns error message' do
+    a = MassSeedPoints.generate(number_of_points: 0, city: '')
+    assert_equal 'No boundingbox found in which to insert points! Have you supplied a geolocation (city, district, ...)?', a
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,6 +30,7 @@ Geocoder::Lookup::Test.set_default_stub(
         'town' => 'Berlin',
       },
       'type' => 'house',
+      'boundingbox' => [52.5, 52.3, 13.0, 12.5],
     }
   ]
 )


### PR DESCRIPTION
Use with `rake mass_seed_points <no_of_points> <city_name>`

Example: `rake mass_seed_points 100 Berlin` will add 100 random POIs with random descriptions and (non-valid) addresses within the bbox of Berlin. Random categories are automatically created (~10) and associated! 