### PR TITLE
Geocoding changes

### DIFF
--- a/app/assets/javascripts/map.js.erb
+++ b/app/assets/javascripts/map.js.erb
@@ -145,22 +145,29 @@ jQuery(function() {
       window.location.href = 'places/new';
     });
 
+    var locationMarker;
+
+    function confirmPlaceInsert(lat, lon) {
+      map.setView([lat, lon], 18);
+      if (locationMarker) {
+        map.removeLayer(locationMarker);
+      }
+      locationMarker = L.circleMarker([lat, lon]).addTo(map);
+      jQuery('.confirmation-button-container').fadeIn();
+      jQuery('#confirmation-button-yes').click(function() {
+        jQuery('.confirmation-button-container').fadeOut();
+        var params = 'longitude=' + lon + '&' + 'latitude=' +  lat;
+        window.location.href = 'places/new?' + params;
+      });
+      jQuery('#confirmation-button-no').click(function() {
+        jQuery('.confirmation-button-container').fadeOut();
+        window.location.href = 'places/new';
+      });
+    };
+
     jQuery('.add-place-via-location').click(function(){
       function confirmation(position) {
-        var longitude = position.coords.longitude;
-        var latitude = position.coords.latitude;
-        map.setView([latitude, longitude], 18);
-        var myLocationMarker = L.circleMarker([latitude, longitude]).addTo(map);
-        jQuery('.confirmation-button-container').fadeIn();
-        jQuery('#confirmation-button-yes').click(function() {
-          jQuery('.confirmation-button-container').fadeOut();
-          var params = 'longitude=' + longitude + '&' + 'latitude=' +  latitude;
-          window.location.href = 'places/new?' + params;
-        });
-        jQuery('#confirmation-button-no').click(function() {
-          jQuery('.confirmation-button-container').fadeOut();
-          window.location.href = 'places/new';
-        });
+        confirmPlaceInsert(position.coords.latitude, position.coords.longitude);
       };
 
       var errorMessageAppendix = window.geolocation_error_message_appendix;
@@ -185,6 +192,14 @@ jQuery(function() {
       };
 
     });
+
+    jQuery('.add_place_via_click').click(function(){
+      jQuery('.leaflet-overlay-pane').css('cursor','crosshair');
+      map.on('click', function(point) {
+        confirmPlaceInsert(point.latlng.lat, point.latlng.lng);
+      });
+    });
+
 
     // FRONTEND STUFF
     var toggleTriangle = function(e) {

--- a/app/assets/javascripts/map.js.erb
+++ b/app/assets/javascripts/map.js.erb
@@ -165,33 +165,19 @@ jQuery(function() {
       });
     };
 
-    jQuery('.add-place-via-location').click(function(){
-      function confirmation(position) {
-        confirmPlaceInsert(position.coords.latitude, position.coords.longitude);
-      };
+    // Google geolocation API not working properly, so freeze this feature
 
-      var errorMessageAppendix = window.geolocation_error_message_appendix;
-      if (navigator.geolocation) {
-        navigator.geolocation.getCurrentPosition(
-          confirmation,
-          displayError,
-          { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
-        );
-      }
-      else {
-        alert('Positioning not available. ' + errorMessageAppendix);
-      }
-
-      function displayError(error) {
-        var errors = {
-          1: 'Permission denied. ',
-          2: 'Position unavailable. ',
-          3: 'Request timeout. '
-        };
-        alert(errors[error.code] + errorMessageAppendix);
-      };
-
-    });
+    // jQuery('.add-place-via-location').click(function(){
+    //   function confirmation(position) {
+    //     confirmPlaceInsert(position.coords.latitude, position.coords.longitude);
+    //   };
+    //
+    //   if (navigator.geolocation) {
+    //     navigator.geolocation.getCurrentPosition(confirmation);
+    //   } else {
+    //     console.log('Geolocation is not supported by this browser.');
+    //   };
+    // });
 
     jQuery('.add_place_via_click').click(function(){
       jQuery('.leaflet-overlay-pane').css('cursor','crosshair');

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -68,6 +68,11 @@ class PlacesController < ApplicationController
   end
 
   def save_update
+    # Ugly: lat/lon have to be inserted into modified_params-hash in order to make update_attributes work...
+    if @place.latitude && @place.longitude
+      modified_params[:latitude] = @place.latitude
+      modified_params[:longitude] = @place.longitude
+    end
     if @place.update_attributes(modified_params)
       flash[:success] = 'Changes saved! Wait for review...'
       redirect_to places_path
@@ -78,6 +83,7 @@ class PlacesController < ApplicationController
   end
 
   def save_new
+    # Take lat/lon values from hash passed by create form
     @place.latitude ||= params[:place][:latitude]
     @place.longitude ||= params[:place][:longitude]
     if @place.save
@@ -99,7 +105,6 @@ class PlacesController < ApplicationController
       category_param = place_params[:categories] || []
       modified_params[:categories] = category_param.reject(&:empty?).join(',')
     end
-    place_params[:categories]
     modified_params
   end
 

--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -78,6 +78,8 @@ class PlacesController < ApplicationController
   end
 
   def save_new
+    @place.latitude ||= params[:place][:latitude]
+    @place.longitude ||= params[:place][:longitude]
     if @place.save
       if !cookies[:created_places_in_session]
         cookies[:created_places_in_session] = @place.id.to_s
@@ -105,6 +107,7 @@ class PlacesController < ApplicationController
     params.require(:place).permit(
     :name, :street, :house_number, :postal_code, :city,
     :description_en, :description_de, :description_fr, :description_ar, :reviewed,
+    :latitude, :longitude,
     categories: []
     )
   end

--- a/app/helpers/places_helper.rb
+++ b/app/helpers/places_helper.rb
@@ -3,7 +3,7 @@ module PlacesHelper
     raw link_to Category.find(category_id).name, category_path(category_id)
   end
 
-  def address(place)
-    "#{place.street} #{place.house_number}, #{place.postal_code} #{place.city}"
+  def last_places_created
+    Place.all.sort_by(&:created_at).reverse
   end
 end

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -15,7 +15,7 @@ class Place < ActiveRecord::Base
 
   ## VALIDATIONS
   validates :postal_code, format: { with: /\d{5}/, message: 'supply valid postal code (5 digits)' },
-    unless: 'postal_code.empty?' 
+    unless: 'postal_code.empty?'
 
   ## TRANSLATION
   translates :description, versioning: { gem: :paper_trail, options: { on: [:update, :create] } }
@@ -26,6 +26,10 @@ class Place < ActiveRecord::Base
   before_validation :sanitize_descriptions, on: [:create, :update]
   after_validation :geocode_with_nodes, if: :address_changed?, on: [:create, :update]
   after_create :auto_translate if Rails.env != 'test'
+
+  def address
+    ["#{street} #{house_number}", "#{postal_code} #{city}"].select { |e| !e.strip.empty? }.join(',')
+  end
 
   ## MODEL AUDITING
   has_paper_trail on: [:create, :update], ignore: [:reviewed, :description]

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -15,7 +15,7 @@ class Place < ActiveRecord::Base
 
   ## VALIDATIONS
   validates :postal_code, format: { with: /\d{5}/, message: 'supply valid postal code (5 digits)' },
-    unless: 'postal_code.empty?'
+    unless: 'postal_code.nil? || postal_code.empty?'
   validates :name, presence: true
 
   ## TRANSLATION
@@ -25,7 +25,8 @@ class Place < ActiveRecord::Base
   ## CALLBACKS
   geocoded_by :address
   before_validation :sanitize_descriptions, on: [:create, :update]
-  after_validation :geocode_with_nodes, if: :address_changed?, on: [:create, :update]
+  before_save :geocode_with_nodes, unless: 'lat_lon_present?'
+  before_update :geocode_with_nodes, if: 'address_changed?'
   after_create :auto_translate if Rails.env != 'test'
 
   def address

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -14,8 +14,8 @@ class Place < ActiveRecord::Base
   end
 
   ## VALIDATIONS
-  validates_presence_of :name, :street, :city, :postal_code
-  validates :postal_code, format: { with: /\d{5}/, message: 'supply valid postal code (5 digits)' }
+  validates :postal_code, format: { with: /\d{5}/, message: 'supply valid postal code (5 digits)' },
+    unless: 'postal_code.empty?' 
 
   ## TRANSLATION
   translates :description, versioning: { gem: :paper_trail, options: { on: [:update, :create] } }
@@ -23,8 +23,8 @@ class Place < ActiveRecord::Base
 
   ## CALLBACKS
   geocoded_by :address
-  before_validation :geocode_with_nodes, if: :address_changed?, on: [:create, :update]
   before_validation :sanitize_descriptions, on: [:create, :update]
+  after_validation :geocode_with_nodes, if: :address_changed?, on: [:create, :update]
   after_create :auto_translate if Rails.env != 'test'
 
   ## MODEL AUDITING

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -25,8 +25,8 @@ class Place < ActiveRecord::Base
   ## CALLBACKS
   geocoded_by :address
   before_validation :sanitize_descriptions, on: [:create, :update]
-  before_save :geocode_with_nodes, unless: 'lat_lon_present?'
-  before_update :geocode_with_nodes, if: 'address_changed?'
+  before_create :geocode_with_nodes, unless: 'lat_lon_present?'
+  before_update :geocode_with_nodes, if: :address_changed?
   after_create :auto_translate if Rails.env != 'test'
 
   def address

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -16,6 +16,7 @@ class Place < ActiveRecord::Base
   ## VALIDATIONS
   validates :postal_code, format: { with: /\d{5}/, message: 'supply valid postal code (5 digits)' },
     unless: 'postal_code.empty?'
+  validates :name, presence: true
 
   ## TRANSLATION
   translates :description, versioning: { gem: :paper_trail, options: { on: [:update, :create] } }

--- a/app/models/place/geocoding.rb
+++ b/app/models/place/geocoding.rb
@@ -3,6 +3,10 @@ module Geocoding
     street_changed? || city_changed? || house_number_changed? || postal_code_changed?
   end
 
+  def lat_lon_present?
+    latitude.present? && longitude.present?
+  end
+
   def geocode_with_nodes
     results = Geocoder.search(address)
     unless results.any?
@@ -11,8 +15,6 @@ module Geocoding
     end
     node_geoms = results.select { |result| result.type == 'node' }
     other_geoms = results - node_geoms
-    # Prefer point objects (locations, houses, etc.) given by nominatim
-    # ...else take lat/lon of other geoms (lines, etc.)
     if node_geoms.any?
       self.latitude = node_geoms.first.latitude
       self.longitude = node_geoms.first.longitude

--- a/app/models/place/geocoding.rb
+++ b/app/models/place/geocoding.rb
@@ -1,6 +1,6 @@
 module Geocoding
   def address
-    "#{street} #{house_number}, #{postal_code} #{city}"
+    ["#{street} #{house_number}", "#{postal_code} #{city}"].compact.join(',')
   end
 
   def address_changed?

--- a/app/models/place/geocoding.rb
+++ b/app/models/place/geocoding.rb
@@ -1,8 +1,4 @@
 module Geocoding
-  def address
-    ["#{street} #{house_number}", "#{postal_code} #{city}"].compact.join(',')
-  end
-
   def address_changed?
     street_changed? || city_changed? || house_number_changed? || postal_code_changed?
   end

--- a/app/views/places/_form.html.haml
+++ b/app/views/places/_form.html.haml
@@ -50,6 +50,8 @@
       = show_simple_captcha unless signed_in?
   .row.margin-below
     .col-xs-6
+      = f.hidden_field :latitude, value: params[:latitude]
+      = f.hidden_field :longitude, value: params[:longitude]
       = f.submit class: 'btn btn-primary btn-success place-form-button'
     .col-xs-6.col-md-2
       = link_to t('back'), '', class: 'btn btn-primary btn-danger place-form-button back-button'

--- a/app/views/places/index.html.haml
+++ b/app/views/places/index.html.haml
@@ -20,7 +20,7 @@
               .col-xs-3
                 = place.name
               .col-xs-4
-                = address(place)
+                = place.address
               .col-xs-3
                 - if place.category_ids
                   - place.category_ids.each do |id|

--- a/app/views/review/review_index.html.haml
+++ b/app/views/review/review_index.html.haml
@@ -8,7 +8,7 @@
           .col-xs-3
             = place.name
           .col-xs-5
-            = address(place)
+            = place.address
           .col-xs-2.red
             - if place.new?
               NEW

--- a/app/views/review/review_place.html.haml
+++ b/app/views/review/review_place.html.haml
@@ -9,7 +9,7 @@
             %h4
               = @reviewed_place.name
           .col-xs-8
-            = address(@reviewed_place)
+            = @reviewed_place.address
           .col-xs-4
             %b Categories:
             - if @reviewed_place.category_names.empty?
@@ -29,7 +29,7 @@
             %h4
               = @unreviewed_place.name
           .col-xs-8
-            = address(@unreviewed_place)
+            = @unreviewed_place.address
           .col-xs-4
             %b Categories:
             - if @unreviewed_place.category_names.empty?

--- a/app/views/static_pages/_add_place_slidepanel.html.haml
+++ b/app/views/static_pages/_add_place_slidepanel.html.haml
@@ -2,12 +2,9 @@
   .hide-slidepanel.glyphicon.glyphicon-remove.pull-right
   %h4.slidepanel-title= t('how_to_add_place?')
   .content
-    .col-xs-12.col-sm-4
-      %button.add-place-buttons.add-place-via-location.btn.btn-dark{'data-dismiss': 'modal', type: 'button'}
-        = t('add_place_via_location')
-    .col-xs-12.col-sm-4
+    .col-xs-12.col-sm-6
       %button.add-place-buttons.type-in-address.btn.btn-dark{'data-dismiss': 'modal', type: 'button'}
         = t('type-in_address')
-    .col-xs-12.col-sm-4
+    .col-xs-12.col-sm-6
       %button.add-place-buttons.add_place_via_click.btn.btn-dark{'data-dismiss': 'modal', type: 'button'}
         = t('add_via_mouseclick')

--- a/app/views/static_pages/_add_place_slidepanel.html.haml
+++ b/app/views/static_pages/_add_place_slidepanel.html.haml
@@ -2,9 +2,12 @@
   .hide-slidepanel.glyphicon.glyphicon-remove.pull-right
   %h4.slidepanel-title= t('how_to_add_place?')
   .content
-    .col-xs-12.col-sm-6
+    .col-xs-12.col-sm-4
       %button.add-place-buttons.add-place-via-location.btn.btn-dark{'data-dismiss': 'modal', type: 'button'}
         = t('add_place_via_location')
-    .col-xs-12.col-sm-6
+    .col-xs-12.col-sm-4
       %button.add-place-buttons.type-in-address.btn.btn-dark{'data-dismiss': 'modal', type: 'button'}
         = t('type-in_address')
+    .col-xs-12.col-sm-4
+      %button.add-place-buttons.add_place_via_click.btn.btn-dark{'data-dismiss': 'modal', type: 'button'}
+        = t('add_via_mouseclick')

--- a/db/migrate/20160826153724_place_address_features_can_be_null.rb
+++ b/db/migrate/20160826153724_place_address_features_can_be_null.rb
@@ -1,0 +1,7 @@
+class PlaceAddressFeaturesCanBeNull < ActiveRecord::Migration
+  def change
+    change_column :places, :street, :string, :null => true
+    change_column :places, :postal_code, :string, :null => true
+    change_column :places, :city, :string, :null => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160807205253) do
+ActiveRecord::Schema.define(version: 20160826153724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,10 +61,10 @@ ActiveRecord::Schema.define(version: 20160807205253) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.string   "name",                         null: false
-    t.string   "postal_code",                  null: false
-    t.string   "street",                       null: false
+    t.string   "postal_code"
+    t.string   "street"
     t.string   "house_number"
-    t.string   "city",                         null: false
+    t.string   "city"
     t.boolean  "reviewed",     default: false, null: false
     t.text     "categories",   default: ""
   end

--- a/test/controllers/places_controller_test.rb
+++ b/test/controllers/places_controller_test.rb
@@ -30,11 +30,18 @@ class PlacesControllerTest < ActionController::TestCase
                              house_number: '15',
                              postal_code: '10365',
                              city: 'Berlin',
-                             categories: [],
-                            }
+                             categories: [] }
     end
 
     assert_redirected_to root_path(latitude: 52.0, longitude: 12.0)
+  end
+
+  test 'place with lat_lon provided does not need to be geocoded' do
+    assert_difference 'Place.count' do
+      post :create, place: { name: 'SomePlace',
+                             latitude: 13,
+                             longitude: 52 }
+    end
   end
 
   test 'should not create invalid new place' do
@@ -44,8 +51,7 @@ class PlacesControllerTest < ActionController::TestCase
                              house_number: '15',
                              postal_code: '10365',
                              city: 'Berlin',
-                             categories: [],
-                            }
+                             categories: [] }
     end
   end
 
@@ -73,8 +79,7 @@ class PlacesControllerTest < ActionController::TestCase
                                          house_number: '15',
                                          postal_code: '10365',
                                          city: 'Berlin',
-                                         categories: [],
-                                        }
+                                         categories: [] }
     @place.reload.name
     assert_equal 'Blubb', @place.name
   end
@@ -85,8 +90,7 @@ class PlacesControllerTest < ActionController::TestCase
                                          house_number: '15',
                                          postal_code: '10365',
                                          city: 'Berlin',
-                                         categories: [],
-                                        }
+                                         categories: [] }
     @place.reload.name
     assert_equal 'Hausprojekt Magdalenenstraße 19', @place.name
   end
@@ -105,8 +109,7 @@ class PlacesControllerTest < ActionController::TestCase
                            house_number: '15',
                            postal_code: '10365',
                            city: 'Berlin',
-                           categories: [],
-                          }
+                           categories: [] }
     assert Place.find_by(name: 'katze').reviewed
   end
 
@@ -117,8 +120,7 @@ class PlacesControllerTest < ActionController::TestCase
                            house_number: '15',
                            postal_code: '10365',
                            city: 'Berlin',
-                           categories: [],
-                          }
+                           categories: [] }
     assert_not Place.find_by(name: 'andere katze').reviewed
   end
 end


### PR DESCRIPTION
Ziel: Bei vorhandenen Koordinaten beim neu Erstellen eines POIs keine Adressvalidierung stattfindet, uA um über Mausklick Punkte adden zu können (feature request). Dafür...

* Adress validation rausgenommen
* Add place via (mouse)click feature eingebaut
* Add place via location feature rausgenommen weil disfunktional
* Geocoding-relevante callbacks geändert (siehe `place.rb`), Geocoding nunmehr nur dann, wenn...
  * lat/lon nicht vorhanden ist beim neu erstellen eines Punkts
  * die Adresse sich geändert hat beim updaten eines Punkts

Dafür habe ich etwas im Controller rumgepfuscht, bin auch noch nicht hundertpro zufrieden. Größtes Problem ist, wie die Koordinaten-Daten vom onClick-Event auf der Karte zur Create-Methode im `places-controller` gelangen. Das geschieht über die Weitergabe im params-hash zum Formular, wo die Werte über ein hidden-field-tag ins params[:place]-hash weitergereicht werden. Is alles son bisschen mmhhhh, funktioniert aber. Denk da heut nochmal drüber nach, wenn du oder ich da keine bessere Idee für finden würd ichs erstmal so mergen und dann ggf. die Leiche später ausm Keller holen